### PR TITLE
Truncate long urls on mobile

### DIFF
--- a/app/assets/stylesheets/components/restaurant.scss
+++ b/app/assets/stylesheets/components/restaurant.scss
@@ -13,9 +13,46 @@
 
     .contact-details {
       font-size: 13px;
+      display: flex;
+      flex-direction: row;
+      
+      a[href*="tel:"] {
+        flex-basis: auto;
+        flex-shrink: 0;
+        flex-grow: 0;
+        display: inline-block;
+        white-space: nowrap;
+        
+        @media #{$small-and-down} {
+          margin-left: 20px;
+          margin-right: auto;
+          text-align: right;
+        }
+        
+      }
       
       .separator {
-        margin: 10px 5px;
+        display: none;
+        
+        @media #{$medium-and-up} {
+          display: inline;
+          margin: 0 10px;
+          flex-basis: 0;
+          flex-shrink: 1;
+          flex-grow: 0;  
+        }
+      }
+      
+      .contact-restaurant-website {
+        flex-grow: 0;
+        flex-basis: auto;
+        flex-shrink: 1;
+        overflow-x: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        @media #{$small-and-down} {
+          flex-grow: 1;
+        }
       }
     }
   }

--- a/app/javascript/components/restaurant.jsx
+++ b/app/javascript/components/restaurant.jsx
@@ -11,7 +11,7 @@ class Restaurant extends React.Component {
           <div className='contact-details'>
             {
               restaurant.website &&
-              <a href={`${restaurant.website}`} target="_blank">
+              <a href={`${restaurant.website}`} className='contact-restaurant-website' target="_blank">
                 {restaurant.website}
               </a>
             }


### PR DESCRIPTION
Fixes #23 

## On mobile view:

* the website and phone number are on a single row, making both have distinct and clear tap targets
* the website gets truncated if too long
* the phone number gets aligned to the right (always)
* the separator is hidden, replaced with a margin (the separator looked weird if the URL wasn't long, and the phone number being on the right)

<img width="337" alt="Screen Shot 2020-03-29 at 5 25 31 PM" src="https://user-images.githubusercontent.com/104179/77861342-56247980-71e2-11ea-886a-300a444e5281.png">

## On medium or larger screens:

* The website and phone number are aligned left
* The seperator is shown
* If the URL is super long, it'll get truncated so that the whole row isn't wrapped.

<img width="802" alt="Screen Shot 2020-03-29 at 5 25 38 PM" src="https://user-images.githubusercontent.com/104179/77861347-5d4b8780-71e2-11ea-8dfc-3a0a435b6ad1.png">
